### PR TITLE
change to .party base urls

### DIFF
--- a/app/src/main/java/com/github/xhea1/party/app/Party.java
+++ b/app/src/main/java/com/github/xhea1/party/app/Party.java
@@ -38,7 +38,7 @@ class Party {
 
     @SuppressWarnings("unused")
     enum Site {
-        COOMER("https://coomer.su/"), KEMONO("https://kemono.su/");
+        COOMER("https://coomer.party/"), KEMONO("https://kemono.party/");
 
         private final String baseUrl;
 


### PR DESCRIPTION
Domains for the services have moved. The .party URL will always redirect to the current domain.